### PR TITLE
Create docker-compose.yml for quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Verigate Server is a robust, secure, and standards-compliant OAuth 2.0 and OpenI
 
 ### Installation
 
-#### Using Docker (Recommended)
+#### Quick Start (Using docker, Recommended)
 
 ```bash
 # Clone the repository

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Verigate Server is a robust, secure, and standards-compliant OAuth 2.0 and OpenI
 
 ### Installation
 
-#### Quick Start (Using docker, Recommended)
+#### Quick Start (Using Docker, Recommended)
 
 ```bash
 # Clone the repository

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,11 @@ services:
     image: postgres:13
     container_name: verigate-postgres
     environment:
-      POSTGRES_DB: verigate
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: verigate_password_123
+      POSTGRES_DB: ${POSTGRES_DB:-verigate}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     ports:
-      - "127.0.0.1:5433:5432"
+      - "127.0.0.1:${POSTGRES_PORT:-5432}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     networks:
@@ -31,9 +31,9 @@ services:
 
   redis:
     image: redis:6
-    container_name: verigate-redis
+    container_name: verigate-redisdo
     ports:
-      - "127.0.0.1:6379:6379"
+      - "127.0.0.1:${REDIS_PORT:-6379}:6379"
     volumes:
       - redis_data:/data
     networks:
@@ -62,7 +62,7 @@ services:
       dockerfile: Dockerfile
     container_name: verigate-server
     ports:
-      - "8080:8080"
+      - "${APP_PORT:-8080}:${APP_PORT:-8080}"
     env_file:
       - .env
     environment:
@@ -83,7 +83,7 @@ services:
         max-size: "20m"
         max-file: "5"
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/health"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:${APP_PORT:-8080}/health"]
       interval: 5s
       timeout: 2s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,100 @@
+services:
+  postgres:
+    image: postgres:13
+    container_name: verigate-postgres
+    environment:
+      POSTGRES_DB: verigate
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: verigate_password_123
+    ports:
+      - "127.0.0.1:5433:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - verigate-network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 2s
+      timeout: 1s
+      retries: 3
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+    command: >
+      postgres
+      -c shared_buffers=256MB
+      -c max_connections=200
+      -c effective_cache_size=1GB
+
+  redis:
+    image: redis:6
+    container_name: verigate-redis
+    ports:
+      - "127.0.0.1:6379:6379"
+    volumes:
+      - redis_data:/data
+    networks:
+      - verigate-network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 2s
+      timeout: 1s
+      retries: 3
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+    command: >
+      redis-server
+      --appendonly yes
+      --appendfsync everysec
+      --maxmemory 256mb
+      --maxmemory-policy allkeys-lru
+
+  verigate-server:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: verigate-server
+    ports:
+      - "8080:8080"
+    env_file:
+      - .env
+    environment:
+      # Host override for host network
+      POSTGRES_HOST: postgres
+      REDIS_HOST: redis
+    networks:
+      - verigate-network
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "20m"
+        max-file: "5"
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/health"]
+      interval: 5s
+      timeout: 2s
+      retries: 3
+      start_period: 10s
+
+volumes:
+  postgres_data:
+    driver: local
+  redis_data:
+    driver: local
+
+networks:
+  verigate-network:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
 
   redis:
     image: redis:6
-    container_name: verigate-redisdo
+    container_name: verigate-redis
     ports:
       - "127.0.0.1:${REDIS_PORT:-6379}:6379"
     volumes:


### PR DESCRIPTION
Create docker-compose.yml described in README for quick start.
it includes Redis 6, PostgreSQL 13 and runs based on env file.

To describe the goal of Docker method more clearly, I also editted the title of "Using docker" section to "Quick start (Using Docker)".

<img width="609" alt="스크린샷 2025-05-26 오후 3 12 39" src="https://github.com/user-attachments/assets/da37f168-3b4f-43e5-86e7-0bad07393182" />